### PR TITLE
API: replace --split-pattern with --sample-id-pattern 

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ fq-manifestor [OPTIONS] INPUT_DIR OUTPUT_FP
 | Option | Default | Description |
 | --- | --- | --- |
 | `--fq-extensions TEXT` | `fastq.gz,fq.gz` | Comma-separated list of fastq file extensions to search for. |
-| `--split-pattern TEXT` | `_` | Regex pattern used to split filenames to extract sample IDs. |
+| `--sample-id-pattern TEXT` | `(.*?)_` | Regex with a capture group used to extract the sample ID from filenames. |
 | `--f-read-pattern TEXT` | `_R1_` | Regex pattern identifying forward reads. |
 | `--r-read-pattern TEXT` | `_R2_` | Regex pattern identifying reverse reads. |
 | `--filter-pattern TEXT` | | Optional substring; only files containing this string are included. |

--- a/fq_manifestor/_core.py
+++ b/fq_manifestor/_core.py
@@ -7,7 +7,7 @@ import re
 def fq_manifestor(input_dir,
                   output_fp,
                   fq_extensions=['fastq.gz', 'fq.gz'],
-                  split_pattern='_',
+                  sample_id_pattern='(.*?)_',
                   f_read_pattern='_R1_',
                   r_read_pattern='_R2_',
                   filter_pattern=None,
@@ -30,12 +30,10 @@ def fq_manifestor(input_dir,
 
     for fq_filepath in fq_filepaths:
         fq_filename = os.path.basename(fq_filepath)
-        sid_fields = re.split(split_pattern, fq_filename)
-
-        if len(sid_fields) == 1:
+        m = re.search(sample_id_pattern, fq_filename)
+        if not m or not m.group(1):
             raise ValueError('Sample ID not found in file: %s' % fq_filepath)
-        else:
-            sid = sid_fields[0]
+        sid = m.group(1)
 
         if bool(re.search(f_read_pattern, fq_filename)):
             forward = True

--- a/fq_manifestor/cli.py
+++ b/fq_manifestor/cli.py
@@ -29,13 +29,13 @@ def main(
             help="Comma-separated list of fastq file extensions to search for.",
         ),
     ] = "fastq.gz,fq.gz",
-    split_pattern: Annotated[
+    sample_id_pattern: Annotated[
         str,
         typer.Option(
-            "--split-pattern",
-            help="Regex pattern used to split filenames to extract sample IDs.",
+            "--sample-id-pattern",
+            help="Regex with a capture group used to extract the sample ID from filenames.",
         ),
-    ] = "_",
+    ] = "(.*?)_",
     f_read_pattern: Annotated[
         str,
         typer.Option(
@@ -71,7 +71,7 @@ def main(
         input_dir=input_dir,
         output_fp=output_fp,
         fq_extensions=extensions,
-        split_pattern=split_pattern,
+        sample_id_pattern=sample_id_pattern,
         f_read_pattern=f_read_pattern,
         r_read_pattern=r_read_pattern,
         filter_pattern=filter_pattern,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -78,13 +78,13 @@ def test_custom_extensions(tmp_path):
     assert "sampleA" in rows
 
 
-def test_custom_split_pattern(tmp_path):
+def test_custom_sample_id_pattern(tmp_path):
     _touch(tmp_path / "sampleA-S1-L001-R1-001.fastq.gz")
     _touch(tmp_path / "sampleA-S1-L001-R2-001.fastq.gz")
 
     out = tmp_path / "manifest.tsv"
     fq_manifestor(
-        str(tmp_path), str(out), split_pattern="-",
+        str(tmp_path), str(out), sample_id_pattern="(.*?)-",
         f_read_pattern="-R1-", r_read_pattern="-R2-", verbose=False
     )
 


### PR DESCRIPTION
using regex capture group

Uses re.search with a capture group instead of re.split, allowing more flexible sample ID extraction. Default pattern '(.*?)_' preserves existing behavior.